### PR TITLE
Add https before script path URLs so tests work locally

### DIFF
--- a/examples/counter-basic-test/index.html
+++ b/examples/counter-basic-test/index.html
@@ -22,11 +22,11 @@
   <div id="test-app"></div> <!-- Create a test-app div to mount the app -->
   <div id="qunit"></div>    <!-- test results are displayed here -->
   <!-- Load the QUnit CSS file from CDN - require to display our tests -->
-  <link rel="stylesheet" href="//code.jquery.com/qunit/qunit-1.18.0.css">
+  <link rel="stylesheet" href="https://code.jquery.com/qunit/qunit-1.18.0.css">
   <!-- Load the QUnit Testing Framework from CDN - to run the tests -->
-  <script src="//code.jquery.com/qunit/qunit-1.18.0.js"></script>
+  <script src="https://code.jquery.com/qunit/qunit-1.18.0.js"></script>
   <!-- Load Blanket.js from CDN - for test coverage stats -->
-  <script src="//cdnjs.cloudflare.com/ajax/libs/blanket.js/1.1.4/blanket.js">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/blanket.js/1.1.4/blanket.js">
   </script>
   <script src="test.js"></script>  <!-- always load test.js last -->
 </body>

--- a/examples/counter-basic/index.html
+++ b/examples/counter-basic/index.html
@@ -86,11 +86,11 @@ function mount(model, update, view, root_element_id) {
 <div id="test-app"></div> <!-- Create a test-app div to mount the app -->
 <div id="qunit"></div>    <!-- test results are displayed here -->
 <!-- Load the QUnit CSS file from CDN - require to display our tests -->
-<link rel="stylesheet" href="//code.jquery.com/qunit/qunit-1.18.0.css">
+<link rel="stylesheet" href="https://code.jquery.com/qunit/qunit-1.18.0.css">
 <!-- Load the QUnit Testing Framework from CDN - to run the tests -->
-<script src="//code.jquery.com/qunit/qunit-1.18.0.js"></script>
+<script src="https://code.jquery.com/qunit/qunit-1.18.0.js"></script>
 <!-- Load Blanket.js from CDN - for test coverage stats -->
-<script src="//cdnjs.cloudflare.com/ajax/libs/blanket.js/1.1.4/blanket.js">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/blanket.js/1.1.4/blanket.js">
 </script>
 <script src="../counter-basic-test/test.js"></script> <!-- load test.js last -->
 

--- a/examples/counter-reset/index.html
+++ b/examples/counter-reset/index.html
@@ -22,11 +22,11 @@
   <div id="test-app"></div> <!-- Create a test-app div to mount the app -->
   <div id="qunit"></div>    <!-- test results are displayed here -->
   <!-- Load the QUnit CSS file from CDN - require to display our tests -->
-  <link rel="stylesheet" href="//code.jquery.com/qunit/qunit-1.18.0.css">
+  <link rel="stylesheet" href="https://code.jquery.com/qunit/qunit-1.18.0.css">
   <!-- Load the QUnit Testing Framework from CDN - to run the tests -->
-  <script src="//code.jquery.com/qunit/qunit-1.18.0.js"></script>
+  <script src="https://code.jquery.com/qunit/qunit-1.18.0.js"></script>
   <!-- Load Blanket.js from CDN - for test coverage stats -->
-  <script src="//cdnjs.cloudflare.com/ajax/libs/blanket.js/1.1.4/blanket.js">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/blanket.js/1.1.4/blanket.js">
   </script>
   <script src="test.js"></script>  <!-- always load test.js last -->
 </body>


### PR DESCRIPTION
This makes the tests work locally, since with `//`, file:// is used instead of https, for remote URLs.

References #25